### PR TITLE
Tooltip and Chat Spacing

### DIFF
--- a/src/main/java/com/customemoji/ChatSpacingManager.java
+++ b/src/main/java/com/customemoji/ChatSpacingManager.java
@@ -1,0 +1,255 @@
+package com.customemoji;
+
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.*;
+
+@Singleton
+public class ChatSpacingManager
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private CustomEmojiConfig config;
+
+    private final Map<Integer, List<Widget>> originalChatPositions = new HashMap<>();
+    private Integer originalScrollAreaHeight = null;
+
+    public void clearStoredPositions()
+    {
+        originalChatPositions.clear();
+        originalScrollAreaHeight = null;
+    }
+
+    public void applyChatSpacing()
+    {
+        int spacingAdjustment = config.chatMessageSpacing();
+
+        Widget chatbox = client.getWidget(InterfaceID.Chatbox.SCROLLAREA);
+        if (chatbox == null || chatbox.isHidden())
+        {
+            return;
+        }
+
+        if (originalScrollAreaHeight == null)
+        {
+            originalScrollAreaHeight = chatbox.getScrollHeight();
+        }
+
+        // Store current scroll state to preserve relative position
+        int currentScrollY = chatbox.getScrollY();
+        int currentScrollHeight = chatbox.getScrollHeight();
+        int visibleHeight = chatbox.getHeight();
+        
+        // Calculate scroll position relative to bottom (more intuitive for chat)
+        boolean wasAtBottom = (currentScrollY + visibleHeight >= currentScrollHeight - 5); // 5px tolerance
+        double scrollPercentage = currentScrollHeight > 0 ? (double) currentScrollY / currentScrollHeight : 0;
+
+        Widget[] dynamicChildren = chatbox.getDynamicChildren();
+        Widget[] staticChildren = chatbox.getStaticChildren();
+
+        // Handle null arrays
+        if (dynamicChildren == null) dynamicChildren = new Widget[0];
+        if (staticChildren == null) staticChildren = new Widget[0];
+
+        // Merge the arrays
+        Widget[] allChildren = new Widget[dynamicChildren.length + staticChildren.length];
+        System.arraycopy(dynamicChildren, 0, allChildren, 0, dynamicChildren.length);
+        System.arraycopy(staticChildren, 0, allChildren, dynamicChildren.length, staticChildren.length);
+
+        adjustChildren(allChildren, spacingAdjustment);
+
+        // Calculate new scroll height based on all content
+        int maxY = 0;
+        int maxHeight = 0;
+        for (Widget child : allChildren)
+        {
+            if (child != null && !child.isHidden())
+            {
+                int childBottom = child.getOriginalY() + child.getOriginalHeight();
+                if (childBottom > maxY + maxHeight)
+                {
+                    maxY = child.getOriginalY();
+                    maxHeight = child.getOriginalHeight();
+                }
+            }
+        }
+        
+        Widget firstWidget = chatbox.getStaticChildren()[0];
+
+        if (firstWidget == null)
+        {
+            return;
+        }
+        int newScrollHeight = firstWidget.getOriginalY() + firstWidget.getHeight() + 2;
+        chatbox.setScrollHeight(newScrollHeight);
+        
+        // Restore scroll position intelligently
+        if (wasAtBottom)
+        {
+            // Keep user at bottom if they were at bottom before
+            int newScrollY = Math.max(0, newScrollHeight - visibleHeight);
+            chatbox.setScrollY(newScrollY);
+        }
+        else
+        {
+            // Try to maintain relative scroll position
+            int newScrollY = (int) (scrollPercentage * newScrollHeight);
+            newScrollY = Math.max(0, Math.min(newScrollY, newScrollHeight - visibleHeight));
+            chatbox.setScrollY(newScrollY);
+        }
+    }
+
+    private void adjustChildren(Widget[] children, int spacingAdjustment)
+    {
+        if (children == null)
+        {
+            return;
+        }
+
+        // Sort the array so that we adjust them in the proper order. The parent widget 
+        // has them in the proper order, but split by static or dynamic widget category.
+        Widget[] sortedChildren = sortByYPosition(children);
+
+        // Reverse the children array so last becomes first. 
+        // This makes it simpler to adjust the positions of every widget.
+        // We start at the oldest message at the very top and work our way down
+        Widget[] reversedSortedChildren = reverseArrayOrder(sortedChildren);
+
+        // Group widgets by their original Y position
+        Map<Integer, List<Widget>> widgetsByOriginalY = new HashMap<>();
+        
+        for (int i = 0; i < reversedSortedChildren.length; i++)
+        {
+            Widget child = reversedSortedChildren[i];
+
+            if (child.isHidden() || child == null)
+            {
+                continue;
+            }
+
+            int currentY = child.getOriginalY();
+            int storedY;
+            
+            // Check if we have a stored position for this widget
+            Integer foundStoredY = getStoredYPosition(child);
+            if (foundStoredY != null && foundStoredY != currentY)
+            {
+                // Widget already has a stored position, use it
+                storedY = foundStoredY;
+            }
+            else
+            {
+                // New widget or position hasn't been stored yet
+                // For new widgets, we need to figure out their TRUE original position
+                // by removing any spacing that might have been applied
+                
+                // Check if this widget is already stored
+                boolean isAlreadyStored = false;
+                for (List<Widget> widgets : originalChatPositions.values())
+                {
+                    if (widgets.contains(child))
+                    {
+                        isAlreadyStored = true;
+                        break;
+                    }
+                }
+                
+                if (!isAlreadyStored)
+                {
+                    // This is a new widget, store it at current position
+                    // (which should be the original position if it's truly new)
+                    storedY = currentY;
+                    
+                    // Add to stored positions
+                    originalChatPositions.computeIfAbsent(storedY, k -> new ArrayList<>()).add(child);
+                }
+                else
+                {
+                    // Widget is stored but we couldn't find it (shouldn't happen)
+                    storedY = currentY;
+                }
+            }
+
+            // Use stored Y position for grouping
+            widgetsByOriginalY.computeIfAbsent(storedY, k -> new ArrayList<>()).add(child);
+        }
+
+        // Sort the original Y positions and apply spacing to each group
+        List<Integer> sortedOriginalYs = new ArrayList<>(widgetsByOriginalY.keySet());
+        sortedOriginalYs.sort(Integer::compareTo);
+        
+        int counter = 0;
+        for (Integer originalYPos : sortedOriginalYs)
+        {
+            List<Widget> widgetsAtThisY = widgetsByOriginalY.get(originalYPos);
+            int newY = originalYPos + (counter * spacingAdjustment);
+            
+            // Apply the same Y position and settings to all widgets at the same original y position
+            // This is done so that all elements line up with each other.
+            for (Widget child : widgetsAtThisY)
+            {                
+                child.setOriginalY(newY);
+                child.revalidate();
+            }
+            
+            counter++;
+        }
+        
+        return;
+    }
+
+    private Widget[] sortByYPosition(Widget[] array)
+    {
+        // Sort by stored Y position
+        Arrays.sort(array, (w1, w2) -> {
+            if (w1 == null && w2 == null) return 0;
+            if (w1 == null) return 1;
+            if (w2 == null) return -1;
+            
+            // Find the stored Y position for each widget by searching through originalChatPositions
+            Integer storedY1 = getStoredYPosition(w1);
+            Integer storedY2 = getStoredYPosition(w2);
+            
+            // Use stored position if available, otherwise use current position
+            int y1 = storedY1 != null ? storedY1 : w1.getOriginalY();
+            int y2 = storedY2 != null ? storedY2 : w2.getOriginalY();
+            
+            return Integer.compare(y1, y2);
+        });
+
+        return array;
+    }
+    
+    private Integer getStoredYPosition(Widget widget)
+    {
+        // Search through originalChatPositions to find which Y position this widget belongs to
+        for (Map.Entry<Integer, List<Widget>> entry : originalChatPositions.entrySet())
+        {
+            if (entry.getValue().contains(widget))
+            {
+                return entry.getKey();
+            }
+        }
+        // If not found in stored positions, return null
+        return null;
+    }
+
+    private static Widget[] reverseArrayOrder(Widget[] array)
+    {
+        int len = array.length;
+        Widget[] result = new Widget[len];
+        
+        for (int i = 0; i < len; i++)
+        {
+            result[i] = array[len - 1 - i];
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/customemoji/CustomEmojiConfig.java
+++ b/src/main/java/com/customemoji/CustomEmojiConfig.java
@@ -5,11 +5,6 @@ import net.runelite.client.config.*;
 @ConfigGroup("custom-emote")
 public interface CustomEmojiConfig extends Config
 {
-
-
-
-
-
 	// Info section
 	@ConfigSection(
 			name = "Info",
@@ -67,7 +62,7 @@ public interface CustomEmojiConfig extends Config
 
 	@ConfigItem(
 		keyName = "suggestion_overlay",
-		name = "Show Overlay",
+		name = "Show Suggestion Overlay",
 		description = "Displays a list of potential emotes in an overlay while you're typing a chat message.",
 		section = emojiSection,
 		position = 2
@@ -86,9 +81,18 @@ public interface CustomEmojiConfig extends Config
 	)
 	default int maxImageSuggestions() { return 10; }
 
+	@ConfigItem(
+		keyName = "show_emoji_tooltips",
+		name = "Show Emoji Tooltips",
+		description = "Shows the emoji name in a tooltip when hovering over emojis in chat messages.",
+		section = emojiSection,
+		position = 4
+	)
+	default boolean showEmojiTooltips() { return true; }
+
 	// Soundoji section
 	@ConfigSection(
-			name = "Soundoji Settings",
+			name = "Soundoji",
 			description = "Soundoji configuration options",
 			position = 2
 	)
@@ -107,26 +111,24 @@ public interface CustomEmojiConfig extends Config
 		return 70;
 	}
 
-	// Dev section
+	// Chat section
 	@ConfigSection(
-			name = "Dev",
-			description = "Configuration for dev stuff",
+			name = "Chat Widget",
+			description = "Chat display configuration options",
 			position = 3
 	)
-	String devSection = "devSection";
+	String chatSection = "chatSection";
 
 	@ConfigItem(
-		keyName = "message_loaded",
-		name = "Show Loaded Message",
-		description = "Used for development, shows chat messages when emojis are loaded",
-		position = 0,
-		section = devSection
+			keyName = "chat_message_spacing",
+			name = "Chat Message Spacing",
+			description = "Adjusts the vertical spacing between chat messages (in pixels). Default is 0.",
+			section = chatSection,
+			position = 0
 	)
-	default boolean showLoadedMessage()
+	@Range(min = 0, max = 20)
+	default int chatMessageSpacing()
 	{
-		return false;
+		return 0;
 	}
-
-
-
 }

--- a/src/main/java/com/customemoji/CustomEmojiTooltip.java
+++ b/src/main/java/com/customemoji/CustomEmojiTooltip.java
@@ -1,0 +1,279 @@
+package com.customemoji;
+
+import javax.inject.Inject;
+
+import com.customemoji.CustomEmojiPlugin.Emoji;
+
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.game.ChatIconManager;
+import net.runelite.client.input.MouseListener;
+import net.runelite.client.input.MouseManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.awt.event.MouseEvent;
+
+public class CustomEmojiTooltip extends Overlay
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private CustomEmojiConfig config;
+
+    @Inject
+    private CustomEmojiPlugin plugin;
+
+    @Inject
+    private TooltipManager tooltipManager;
+
+    @Inject
+    private MouseManager mouseManager;
+
+    @Inject
+    private ChatIconManager chatIconManager;
+
+    // Tooltip state
+    private String hoveredEmojiName = null;
+    private Point mousePosition = null;
+
+    private final MouseListener mouseListener = new MouseListener()
+	{
+		@Override
+		public MouseEvent mouseClicked(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mousePressed(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseReleased(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseEntered(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseExited(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseDragged(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseMoved(MouseEvent mouseEvent)
+		{
+			Point currentPoint = mouseEvent.getPoint();
+
+			// Only update if mouse actually moved a good bit
+			if (mousePosition == null || 
+				Math.abs(currentPoint.x - mousePosition.x) > 2 || 
+				Math.abs(currentPoint.y - mousePosition.y) > 2)
+			{
+				mousePosition = currentPoint;
+
+				// Delegate to overlay for tooltip handling
+				updateHoveredEmoji(currentPoint);
+			}
+			return mouseEvent;
+		}
+	};
+
+    protected void startUp()
+    {
+        if (mouseManager != null)
+        {
+            mouseManager.registerMouseListener(mouseListener);
+        }
+    }
+
+    protected void shutDown()
+    {
+        if (mouseManager != null)
+        {
+            mouseManager.unregisterMouseListener(mouseListener);
+        }
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        showTooltip();
+        return null;
+    }
+
+    private void showTooltip()
+    {
+        if (hoveredEmojiName != null && !hoveredEmojiName.isEmpty() && config.showEmojiTooltips())
+        {
+            tooltipManager.add(new Tooltip(hoveredEmojiName));
+        }
+    }
+
+    private void updateHoveredEmoji(Point mousePoint)
+    {
+        this.mousePosition = mousePoint;
+
+        String foundEmoji = null;
+
+        Widget chatbox = client.getWidget(InterfaceID.Chatbox.SCROLLAREA);
+        if (chatbox == null)
+        {
+            hoveredEmojiName = null;
+            return;
+        }
+
+        Widget[] dynamicChildren = chatbox.getDynamicChildren();
+        foundEmoji = checkWidgetsForEmoji(dynamicChildren, mousePoint);
+        
+        hoveredEmojiName = foundEmoji;
+    }
+
+    private String checkWidgetsForEmoji(Widget[] widgets, Point mousePoint)
+    {
+        if (widgets == null)
+        {
+            return null;
+        }
+
+        for (Widget widget : widgets)
+        {
+            if (widget == null)
+            {
+                continue;
+            }
+
+            // Check if mouse is within widget bounds
+            if (isPointInWidget(widget, mousePoint))
+            {
+                String text = widget.getText();
+                if (text != null && text.contains("<img="))
+                {
+                    String hoveredEmoji = findEmojiAtPosition(widget, text, mousePoint);
+                    if (hoveredEmoji != null)
+                    {
+                        return hoveredEmoji;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean isPointInWidget(Widget widget, Point point)
+    {
+        int x = widget.getCanvasLocation().getX();
+        int y = widget.getCanvasLocation().getY();
+        int width = widget.getWidth();
+        int height = widget.getHeight();
+        
+        return point.x >= x && point.x <= x + width && 
+               point.y >= y && point.y <= y + height;
+    }
+
+    private String findEmojiAtPosition(Widget widget, String text, Point mousePoint)
+    {
+        // Create a pattern to find all <img=ID> tags
+        Pattern pattern = Pattern.compile("<img=(\\d+)>");
+        Matcher matcher = pattern.matcher(text);
+        
+        // Get widget position and font metrics
+        net.runelite.api.Point widgetPos = widget.getCanvasLocation();
+        FontMetrics fm = client.getCanvas().getFontMetrics(client.getCanvas().getFont());
+        
+        // Calculate relative mouse position within the widget
+        int relativeX = mousePoint.x - widgetPos.getX();
+        
+        // Parse text and find emote positions
+        int textIndex = 0;
+        int currentX = 0;
+        
+        while (matcher.find())
+        {
+            // Calculate text before this emote
+            String textBefore = text.substring(textIndex, matcher.start());
+            // Remove any HTML tags from text before for width calculation
+            String cleanTextBefore = removeHtmlTags(textBefore);
+            
+            // Calculate X position of this emote
+            int textBeforeWidth = fm.stringWidth(cleanTextBefore);
+            int emoteStartX = currentX + textBeforeWidth;
+            
+            // Look up the emoji to get its actual dimensions
+            String imageIdStr = matcher.group(1);
+            int imageId = Integer.parseInt(imageIdStr);
+            String emojiName = findEmojiNameById(imageId);
+            
+            // Use actual emoji dimensions if available, otherwise use defaults
+            int emoteWidth = 18; // Default width estimate
+            if (emojiName != null)
+            {
+                Emoji emoji = plugin.emojis.get(emojiName);
+                if (emoji != null && emoji.getDimension() != null)
+                {
+                    emoteWidth = emoji.getDimension().width;
+                }
+            }
+            
+            int emoteEndX = emoteStartX + emoteWidth;
+            
+            // Check if mouse is within X bounds of this emote
+            if (relativeX >= emoteStartX && relativeX <= emoteEndX)
+            {
+                return emojiName;
+            }
+            
+            // Update position for next iteration
+            currentX = emoteEndX;
+            textIndex = matcher.end();
+        }
+        
+        return null;
+    }
+
+    private String removeHtmlTags(String text)
+    {
+        if (text == null)
+        {
+            return "";
+        }
+        // Remove HTML tags but preserve the text content
+        return text.replaceAll("<[^>]*>", "");
+    }
+
+    private String findEmojiNameById(int imageId)
+    {
+        for (CustomEmojiPlugin.Emoji emoji : plugin.emojis.values())
+        {
+            if (chatIconManager.chatIconIndex(emoji.getId()) == imageId)
+            {
+                return emoji.getText();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
**Implement chat spacing feature**
This allows the user to increase the spacing between messages in their chat so that they can view larger emotes as god intended.

https://github.com/user-attachments/assets/e80de79a-2000-4f9e-9631-1bcddebc9d6c

Fear not, concerned developer! It accurately repositions the chat messages so that none get cut off at either end. It also does all of this without breaking right-click context menu functionality! (like some other plugins tend to do)

It does have the side effect of a single-frame flicker when the client decides it wants to redraw everything. I think there's a possible solution to this, but it requires further testing.

**Implement tooltip feature**
Hovering over an emote in chat will now display a tooltip so you finally learn how to spam monkaligmagigafart with everyone else

https://github.com/user-attachments/assets/ada15e74-00e3-4631-81b0-c875cbc9b7bd