### PR TITLE
Implement image processing

### DIFF
--- a/src/main/java/com/customemoji/ChatSpacingManager.java
+++ b/src/main/java/com/customemoji/ChatSpacingManager.java
@@ -1,0 +1,255 @@
+package com.customemoji;
+
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.*;
+
+@Singleton
+public class ChatSpacingManager
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private CustomEmojiConfig config;
+
+    private final Map<Integer, List<Widget>> originalChatPositions = new HashMap<>();
+    private Integer originalScrollAreaHeight = null;
+
+    public void clearStoredPositions()
+    {
+        originalChatPositions.clear();
+        originalScrollAreaHeight = null;
+    }
+
+    public void applyChatSpacing()
+    {
+        int spacingAdjustment = config.chatMessageSpacing();
+
+        Widget chatbox = client.getWidget(InterfaceID.Chatbox.SCROLLAREA);
+        if (chatbox == null || chatbox.isHidden())
+        {
+            return;
+        }
+
+        if (originalScrollAreaHeight == null)
+        {
+            originalScrollAreaHeight = chatbox.getScrollHeight();
+        }
+
+        // Store current scroll state to preserve relative position
+        int currentScrollY = chatbox.getScrollY();
+        int currentScrollHeight = chatbox.getScrollHeight();
+        int visibleHeight = chatbox.getHeight();
+        
+        // Calculate scroll position relative to bottom (more intuitive for chat)
+        boolean wasAtBottom = (currentScrollY + visibleHeight >= currentScrollHeight - 5); // 5px tolerance
+        double scrollPercentage = currentScrollHeight > 0 ? (double) currentScrollY / currentScrollHeight : 0;
+
+        Widget[] dynamicChildren = chatbox.getDynamicChildren();
+        Widget[] staticChildren = chatbox.getStaticChildren();
+
+        // Handle null arrays
+        if (dynamicChildren == null) dynamicChildren = new Widget[0];
+        if (staticChildren == null) staticChildren = new Widget[0];
+
+        // Merge the arrays
+        Widget[] allChildren = new Widget[dynamicChildren.length + staticChildren.length];
+        System.arraycopy(dynamicChildren, 0, allChildren, 0, dynamicChildren.length);
+        System.arraycopy(staticChildren, 0, allChildren, dynamicChildren.length, staticChildren.length);
+
+        adjustChildren(allChildren, spacingAdjustment);
+
+        // Calculate new scroll height based on all content
+        int maxY = 0;
+        int maxHeight = 0;
+        for (Widget child : allChildren)
+        {
+            if (child != null && !child.isHidden())
+            {
+                int childBottom = child.getOriginalY() + child.getOriginalHeight();
+                if (childBottom > maxY + maxHeight)
+                {
+                    maxY = child.getOriginalY();
+                    maxHeight = child.getOriginalHeight();
+                }
+            }
+        }
+        
+        Widget firstWidget = chatbox.getStaticChildren()[0];
+
+        if (firstWidget == null)
+        {
+            return;
+        }
+        int newScrollHeight = firstWidget.getOriginalY() + firstWidget.getHeight() + 2;
+        chatbox.setScrollHeight(newScrollHeight);
+        
+        // Restore scroll position intelligently
+        if (wasAtBottom)
+        {
+            // Keep user at bottom if they were at bottom before
+            int newScrollY = Math.max(0, newScrollHeight - visibleHeight);
+            chatbox.setScrollY(newScrollY);
+        }
+        else
+        {
+            // Try to maintain relative scroll position
+            int newScrollY = (int) (scrollPercentage * newScrollHeight);
+            newScrollY = Math.max(0, Math.min(newScrollY, newScrollHeight - visibleHeight));
+            chatbox.setScrollY(newScrollY);
+        }
+    }
+
+    private void adjustChildren(Widget[] children, int spacingAdjustment)
+    {
+        if (children == null)
+        {
+            return;
+        }
+
+        // Sort the array so that we adjust them in the proper order. The parent widget 
+        // has them in the proper order, but split by static or dynamic widget category.
+        Widget[] sortedChildren = sortByYPosition(children);
+
+        // Reverse the children array so last becomes first. 
+        // This makes it simpler to adjust the positions of every widget.
+        // We start at the oldest message at the very top and work our way down
+        Widget[] reversedSortedChildren = reverseArrayOrder(sortedChildren);
+
+        // Group widgets by their original Y position
+        Map<Integer, List<Widget>> widgetsByOriginalY = new HashMap<>();
+        
+        for (int i = 0; i < reversedSortedChildren.length; i++)
+        {
+            Widget child = reversedSortedChildren[i];
+
+            if (child.isHidden() || child == null)
+            {
+                continue;
+            }
+
+            int currentY = child.getOriginalY();
+            int storedY;
+            
+            // Check if we have a stored position for this widget
+            Integer foundStoredY = getStoredYPosition(child);
+            if (foundStoredY != null && foundStoredY != currentY)
+            {
+                // Widget already has a stored position, use it
+                storedY = foundStoredY;
+            }
+            else
+            {
+                // New widget or position hasn't been stored yet
+                // For new widgets, we need to figure out their TRUE original position
+                // by removing any spacing that might have been applied
+                
+                // Check if this widget is already stored
+                boolean isAlreadyStored = false;
+                for (List<Widget> widgets : originalChatPositions.values())
+                {
+                    if (widgets.contains(child))
+                    {
+                        isAlreadyStored = true;
+                        break;
+                    }
+                }
+                
+                if (!isAlreadyStored)
+                {
+                    // This is a new widget, store it at current position
+                    // (which should be the original position if it's truly new)
+                    storedY = currentY;
+                    
+                    // Add to stored positions
+                    originalChatPositions.computeIfAbsent(storedY, k -> new ArrayList<>()).add(child);
+                }
+                else
+                {
+                    // Widget is stored but we couldn't find it (shouldn't happen)
+                    storedY = currentY;
+                }
+            }
+
+            // Use stored Y position for grouping
+            widgetsByOriginalY.computeIfAbsent(storedY, k -> new ArrayList<>()).add(child);
+        }
+
+        // Sort the original Y positions and apply spacing to each group
+        List<Integer> sortedOriginalYs = new ArrayList<>(widgetsByOriginalY.keySet());
+        sortedOriginalYs.sort(Integer::compareTo);
+        
+        int counter = 0;
+        for (Integer originalYPos : sortedOriginalYs)
+        {
+            List<Widget> widgetsAtThisY = widgetsByOriginalY.get(originalYPos);
+            int newY = originalYPos + (counter * spacingAdjustment);
+            
+            // Apply the same Y position and settings to all widgets at the same original y position
+            // This is done so that all elements line up with each other.
+            for (Widget child : widgetsAtThisY)
+            {                
+                child.setOriginalY(newY);
+                child.revalidate();
+            }
+            
+            counter++;
+        }
+        
+        return;
+    }
+
+    private Widget[] sortByYPosition(Widget[] array)
+    {
+        // Sort by stored Y position
+        Arrays.sort(array, (w1, w2) -> {
+            if (w1 == null && w2 == null) return 0;
+            if (w1 == null) return 1;
+            if (w2 == null) return -1;
+            
+            // Find the stored Y position for each widget by searching through originalChatPositions
+            Integer storedY1 = getStoredYPosition(w1);
+            Integer storedY2 = getStoredYPosition(w2);
+            
+            // Use stored position if available, otherwise use current position
+            int y1 = storedY1 != null ? storedY1 : w1.getOriginalY();
+            int y2 = storedY2 != null ? storedY2 : w2.getOriginalY();
+            
+            return Integer.compare(y1, y2);
+        });
+
+        return array;
+    }
+    
+    private Integer getStoredYPosition(Widget widget)
+    {
+        // Search through originalChatPositions to find which Y position this widget belongs to
+        for (Map.Entry<Integer, List<Widget>> entry : originalChatPositions.entrySet())
+        {
+            if (entry.getValue().contains(widget))
+            {
+                return entry.getKey();
+            }
+        }
+        // If not found in stored positions, return null
+        return null;
+    }
+
+    private static Widget[] reverseArrayOrder(Widget[] array)
+    {
+        int len = array.length;
+        Widget[] result = new Widget[len];
+        
+        for (int i = 0; i < len; i++)
+        {
+            result[i] = array[len - 1 - i];
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/customemoji/CustomEmojiConfig.java
+++ b/src/main/java/com/customemoji/CustomEmojiConfig.java
@@ -5,11 +5,6 @@ import net.runelite.client.config.*;
 @ConfigGroup("custom-emote")
 public interface CustomEmojiConfig extends Config
 {
-
-
-
-
-
 	// Info section
 	@ConfigSection(
 			name = "Info",
@@ -67,7 +62,7 @@ public interface CustomEmojiConfig extends Config
 
 	@ConfigItem(
 		keyName = "suggestion_overlay",
-		name = "Show Overlay",
+		name = "Show Suggestion Overlay",
 		description = "Displays a list of potential emotes in an overlay while you're typing a chat message.",
 		section = emojiSection,
 		position = 2
@@ -86,9 +81,18 @@ public interface CustomEmojiConfig extends Config
 	)
 	default int maxImageSuggestions() { return 10; }
 
+	@ConfigItem(
+		keyName = "show_emoji_tooltips",
+		name = "Show Emoji Tooltips",
+		description = "Shows the emoji name in a tooltip when hovering over emojis in chat messages.",
+		section = emojiSection,
+		position = 4
+	)
+	default boolean showEmojiTooltips() { return true; }
+
 	// Soundoji section
 	@ConfigSection(
-			name = "Soundoji Settings",
+			name = "Soundoji",
 			description = "Soundoji configuration options",
 			position = 2
 	)
@@ -107,26 +111,24 @@ public interface CustomEmojiConfig extends Config
 		return 70;
 	}
 
-	// Dev section
+	// Chat section
 	@ConfigSection(
-			name = "Dev",
-			description = "Configuration for dev stuff",
+			name = "Chat Widget",
+			description = "Chat display configuration options",
 			position = 3
 	)
-	String devSection = "devSection";
+	String chatSection = "chatSection";
 
 	@ConfigItem(
-		keyName = "message_loaded",
-		name = "Show Loaded Message",
-		description = "Used for development, shows chat messages when emojis are loaded",
-		position = 0,
-		section = devSection
+			keyName = "chat_message_spacing",
+			name = "Chat Message Spacing",
+			description = "Adjusts the vertical spacing between chat messages (in pixels). Default is 0.",
+			section = chatSection,
+			position = 0
 	)
-	default boolean showLoadedMessage()
+	@Range(min = 0, max = 20)
+	default int chatMessageSpacing()
 	{
-		return false;
+		return 0;
 	}
-
-
-
 }

--- a/src/main/java/com/customemoji/CustomEmojiImageUtilities.java
+++ b/src/main/java/com/customemoji/CustomEmojiImageUtilities.java
@@ -1,0 +1,364 @@
+package com.customemoji;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.*;
+import java.util.List;
+
+import net.runelite.client.util.ImageUtil;
+
+/**
+ * Utility class for preprocessing emoji images for RuneLite compatibility.
+ * Handles image resizing, color quantization, and transparency corrections.
+ */
+public class CustomEmojiImageUtilities 
+{
+    // Constants
+    private static final int MAX_PALETTE_SIZE = 255;
+    private static final int NEAR_BLACK_VALUE = 1; // RGB(1,1,1) to avoid transparency issues
+    
+    /**
+     * Normalizes an image by applying resizing, quantization, and black pixel fixes.
+     * @param image The input image to normalize
+     * @param config Configuration settings for resizing
+     * @return The normalized image ready for RuneLite
+     */
+    public static BufferedImage normalizeImage(BufferedImage image, CustomEmojiConfig config)
+    {
+        BufferedImage sizedResult = image;
+        int maxImageHeight = config.maxImageHeight();
+        if (config.resizeEmotes() && image.getHeight() > maxImageHeight)
+        {
+            // Calculate new width while preserving aspect ratio
+            double scaleFactor = (double) maxImageHeight / image.getHeight();
+            int scaledWidth = (int) Math.round(image.getWidth() * scaleFactor);
+            
+            sizedResult = ImageUtil.resizeImage(image, scaledWidth, maxImageHeight, true);
+        }
+
+        BufferedImage quantizedResult = quantizeIfNeeded(sizedResult, MAX_PALETTE_SIZE);
+        return fixPureBlackPixels(quantizedResult);
+    }
+
+    /**
+     * Fixes pure black pixels by converting them to near-black to prevent
+     * RuneLite from treating them as transparent.
+     * @param image The input image
+     * @return Image with corrected black pixels
+     */
+    public static BufferedImage fixPureBlackPixels(BufferedImage image)
+    {
+        BufferedImage result = new BufferedImage(
+            image.getWidth(),
+            image.getHeight(),
+            BufferedImage.TYPE_INT_ARGB
+        );
+        
+        for (int y = 0; y < image.getHeight(); y++)
+        {
+            for (int x = 0; x < image.getWidth(); x++)
+            {
+                int argb = image.getRGB(x, y);
+                int alpha = (argb >> 24) & 0xff;
+                int red = (argb >> 16) & 0xff;
+                int green = (argb >> 8) & 0xff;
+                int blue = argb & 0xff;
+                
+                // If pixel is opaque pure black, make it slightly not-black
+                if (alpha > 0 && red == 0 && green == 0 && blue == 0)
+                {
+                    // Change to RGB (1,1,1) which is visually indistinguishable from black
+                    // but won't be treated as transparent by RuneLite
+                    int newArgb = (alpha << 24) | 
+                                  (NEAR_BLACK_VALUE << 16) | 
+                                  (NEAR_BLACK_VALUE << 8) | 
+                                  NEAR_BLACK_VALUE;
+                    result.setRGB(x, y, newArgb);
+                }
+                else
+                {
+                    result.setRGB(x, y, argb);
+                }
+            }
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Checks if image has more colors than allowed and quantizes if needed.
+     * @param image The input BufferedImage
+     * @param maxColors Maximum number of colors allowed
+     * @return A BufferedImage with maxColors or fewer
+     */
+    public static BufferedImage quantizeIfNeeded(BufferedImage image, int maxColors) {
+        Set<Integer> uniqueColors = getUniqueColors(image);
+        
+        if (uniqueColors.size() <= maxColors) {
+            return image; // No quantization needed
+        }
+        
+        return quantizeToColors(image, maxColors);
+    }
+    
+    /**
+     * Gets all unique colors in the image
+     * @param image The input BufferedImage
+     * @return Set of unique RGB color values
+     */
+    private static Set<Integer> getUniqueColors(BufferedImage image) {
+        Set<Integer> colors = new HashSet<>();
+        
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                colors.add(image.getRGB(x, y));
+            }
+        }
+        
+        return colors;
+    }
+    
+    /**
+     * Quantizes image to specified number of colors using median cut algorithm.
+     * Handles transparency separately to preserve alpha values.
+     * @param image The input BufferedImage
+     * @param maxColors Maximum number of colors
+     * @return Quantized BufferedImage with preserved transparency
+     */
+    private static BufferedImage quantizeToColors(BufferedImage image, int maxColors) {
+        // Separate opaque and transparent colors
+        Set<Integer> uniqueColors = getUniqueColors(image);
+        List<Color> opaqueColors = new ArrayList<>();
+        boolean hasTransparency = false;
+        
+        for (Integer argb : uniqueColors) {
+            Color color = new Color(argb, true);
+            if (color.getAlpha() == 0) {
+                hasTransparency = true;
+            } else {
+                // Only add non-transparent colors to quantization
+                opaqueColors.add(color);
+            }
+        }
+        
+        // Account for transparent color in palette if present
+        int effectiveMaxColors = hasTransparency ? maxColors - 1 : maxColors;
+        
+        // If already within limit, return original
+        if (opaqueColors.size() <= effectiveMaxColors) {
+            return image;
+        }
+        
+        // Apply median cut quantization only to opaque colors
+        List<Color> palette = medianCut(opaqueColors, effectiveMaxColors);
+        
+        // Add transparent color to palette if needed
+        if (hasTransparency) {
+            palette.add(new Color(0, 0, 0, 0));
+        }
+        
+        // Create new quantized image
+        return applyPalette(image, palette);
+    }
+    
+    /**
+     * Median cut algorithm for color quantization
+     */
+    private static List<Color> medianCut(List<Color> colors, int maxColors) {
+        List<ColorBox> boxes = new ArrayList<>();
+        boxes.add(new ColorBox(colors));
+        
+        while (boxes.size() < maxColors) {
+            // Find box with largest range
+            ColorBox largestBox = null;
+            int largestRange = -1;
+            
+            for (ColorBox box : boxes) {
+                int range = box.getLargestRange();
+                if (range > largestRange) {
+                    largestRange = range;
+                    largestBox = box;
+                }
+            }
+            
+            if (largestBox == null || largestRange == 0) {
+                break; // Can't split further
+            }
+            
+            // Split the box
+            ColorBox[] split = largestBox.split();
+            boxes.remove(largestBox);
+            boxes.add(split[0]);
+            boxes.add(split[1]);
+        }
+        
+        // Get average color from each box
+        List<Color> palette = new ArrayList<>();
+        for (ColorBox box : boxes) {
+            palette.add(box.getAverageColor());
+        }
+        
+        return palette;
+    }
+    
+    /**
+     * Apply palette to image using nearest color matching
+     */
+    private static BufferedImage applyPalette(BufferedImage original, List<Color> palette) {
+        BufferedImage result = new BufferedImage(
+            original.getWidth(), 
+            original.getHeight(), 
+            BufferedImage.TYPE_INT_ARGB
+        );
+        
+        for (int y = 0; y < original.getHeight(); y++) {
+            for (int x = 0; x < original.getWidth(); x++) {
+                int argb = original.getRGB(x, y);
+                Color originalColor = new Color(argb, true);
+                
+                // Keep fully transparent pixels as-is
+                if (originalColor.getAlpha() == 0) {
+                    result.setRGB(x, y, 0); // Fully transparent
+                } else {
+                    // For non-transparent pixels, find nearest opaque color
+                    List<Color> opaquePalette = new ArrayList<>();
+                    for (Color c : palette) {
+                        if (c.getAlpha() > 0) {
+                            opaquePalette.add(c);
+                        }
+                    }
+                    Color nearestColor = findNearestColor(originalColor, opaquePalette);
+                    // Combine nearest RGB with original alpha
+                    int newArgb = (originalColor.getAlpha() << 24) | 
+                                  (nearestColor.getRed() << 16) | 
+                                  (nearestColor.getGreen() << 8) | 
+                                  nearestColor.getBlue();
+                    result.setRGB(x, y, newArgb);
+                }
+            }
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Find nearest color in palette using Euclidean distance
+     */
+    private static Color findNearestColor(Color target, List<Color> palette) {
+        Color nearest = palette.get(0);
+        double minDistance = colorDistance(target, nearest);
+        
+        for (Color color : palette) {
+            double distance = colorDistance(target, color);
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearest = color;
+            }
+        }
+        
+        return nearest;
+    }
+    
+    /**
+     * Calculate Euclidean distance between two colors (RGB only, not alpha)
+     */
+    private static double colorDistance(Color c1, Color c2) {
+        int dr = c1.getRed() - c2.getRed();
+        int dg = c1.getGreen() - c2.getGreen();
+        int db = c1.getBlue() - c2.getBlue();
+        // Don't include alpha in distance calculation since we preserve original alpha
+        return Math.sqrt(dr * dr + dg * dg + db * db);
+    }
+    
+    /**
+     * Helper class for median cut algorithm
+     */
+    private static class ColorBox {
+        private List<Color> colors;
+        
+        public ColorBox(List<Color> colors) {
+            this.colors = new ArrayList<>(colors);
+        }
+        
+        public int getLargestRange() {
+            if (colors.isEmpty()) return 0;
+            
+            int minR = 255, maxR = 0;
+            int minG = 255, maxG = 0;
+            int minB = 255, maxB = 0;
+            
+            for (Color color : colors) {
+                minR = Math.min(minR, color.getRed());
+                maxR = Math.max(maxR, color.getRed());
+                minG = Math.min(minG, color.getGreen());
+                maxG = Math.max(maxG, color.getGreen());
+                minB = Math.min(minB, color.getBlue());
+                maxB = Math.max(maxB, color.getBlue());
+            }
+            
+            int rangeR = maxR - minR;
+            int rangeG = maxG - minG;
+            int rangeB = maxB - minB;
+            
+            return Math.max(rangeR, Math.max(rangeG, rangeB));
+        }
+        
+        public ColorBox[] split() {
+            if (colors.size() <= 1) {
+                return new ColorBox[]{this, new ColorBox(new ArrayList<>())};
+            }
+            
+            // Find dimension with largest range
+            int minR = 255, maxR = 0;
+            int minG = 255, maxG = 0;
+            int minB = 255, maxB = 0;
+            
+            for (Color color : colors) {
+                minR = Math.min(minR, color.getRed());
+                maxR = Math.max(maxR, color.getRed());
+                minG = Math.min(minG, color.getGreen());
+                maxG = Math.max(maxG, color.getGreen());
+                minB = Math.min(minB, color.getBlue());
+                maxB = Math.max(maxB, color.getBlue());
+            }
+            
+            int rangeR = maxR - minR;
+            int rangeG = maxG - minG;
+            int rangeB = maxB - minB;
+            
+            // Sort by the dimension with largest range (RGB only)
+            if (rangeR >= rangeG && rangeR >= rangeB) {
+                colors.sort(Comparator.comparingInt(Color::getRed));
+            } else if (rangeG >= rangeB) {
+                colors.sort(Comparator.comparingInt(Color::getGreen));
+            } else {
+                colors.sort(Comparator.comparingInt(Color::getBlue));
+            }
+            
+            // Split at median
+            int median = colors.size() / 2;
+            List<Color> left = colors.subList(0, median);
+            List<Color> right = colors.subList(median, colors.size());
+            
+            return new ColorBox[]{new ColorBox(left), new ColorBox(right)};
+        }
+        
+        public Color getAverageColor() {
+            if (colors.isEmpty()) return Color.BLACK;
+            
+            long sumR = 0, sumG = 0, sumB = 0;
+            for (Color color : colors) {
+                sumR += color.getRed();
+                sumG += color.getGreen();
+                sumB += color.getBlue();
+            }
+            
+            int avgR = (int) (sumR / colors.size());
+            int avgG = (int) (sumG / colors.size());
+            int avgB = (int) (sumB / colors.size());
+            
+            // Return opaque color since we handle alpha separately
+            return new Color(avgR, avgG, avgB);
+        }
+    }
+}

--- a/src/main/java/com/customemoji/CustomEmojiOverlay.java
+++ b/src/main/java/com/customemoji/CustomEmojiOverlay.java
@@ -119,13 +119,9 @@ class CustomEmojiOverlay extends OverlayPanel
     private void addEmojiToOverlay(Emoji emoji)
     {
         BufferedImage bufferedImage = CustomEmojiPlugin.loadImage(emoji.getFile()).unwrap();
+        BufferedImage normalizedImage = CustomEmojiImageUtilities.normalizeImage(bufferedImage, config);
 
-        if (config.resizeEmotes())
-        {
-            bufferedImage = CustomEmojiPlugin.scaleDown(bufferedImage, config.maxImageHeight());
-        }
-
-        ImageComponent imageComponent = new ImageComponent(bufferedImage);
+        ImageComponent imageComponent = new ImageComponent(normalizedImage);
 
         // build line component
         LineComponent lineComponent = LineComponent.builder().right(emoji.getText()).build();

--- a/src/main/java/com/customemoji/CustomEmojiTooltip.java
+++ b/src/main/java/com/customemoji/CustomEmojiTooltip.java
@@ -1,0 +1,279 @@
+package com.customemoji;
+
+import javax.inject.Inject;
+
+import com.customemoji.CustomEmojiPlugin.Emoji;
+
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.game.ChatIconManager;
+import net.runelite.client.input.MouseListener;
+import net.runelite.client.input.MouseManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.awt.event.MouseEvent;
+
+public class CustomEmojiTooltip extends Overlay
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private CustomEmojiConfig config;
+
+    @Inject
+    private CustomEmojiPlugin plugin;
+
+    @Inject
+    private TooltipManager tooltipManager;
+
+    @Inject
+    private MouseManager mouseManager;
+
+    @Inject
+    private ChatIconManager chatIconManager;
+
+    // Tooltip state
+    private String hoveredEmojiName = null;
+    private Point mousePosition = null;
+
+    private final MouseListener mouseListener = new MouseListener()
+	{
+		@Override
+		public MouseEvent mouseClicked(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mousePressed(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseReleased(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseEntered(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseExited(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseDragged(MouseEvent mouseEvent)
+		{
+			return mouseEvent;
+		}
+
+		@Override
+		public MouseEvent mouseMoved(MouseEvent mouseEvent)
+		{
+			Point currentPoint = mouseEvent.getPoint();
+
+			// Only update if mouse actually moved a good bit
+			if (mousePosition == null || 
+				Math.abs(currentPoint.x - mousePosition.x) > 2 || 
+				Math.abs(currentPoint.y - mousePosition.y) > 2)
+			{
+				mousePosition = currentPoint;
+
+				// Delegate to overlay for tooltip handling
+				updateHoveredEmoji(currentPoint);
+			}
+			return mouseEvent;
+		}
+	};
+
+    protected void startUp()
+    {
+        if (mouseManager != null)
+        {
+            mouseManager.registerMouseListener(mouseListener);
+        }
+    }
+
+    protected void shutDown()
+    {
+        if (mouseManager != null)
+        {
+            mouseManager.unregisterMouseListener(mouseListener);
+        }
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        showTooltip();
+        return null;
+    }
+
+    private void showTooltip()
+    {
+        if (hoveredEmojiName != null && !hoveredEmojiName.isEmpty() && config.showEmojiTooltips())
+        {
+            tooltipManager.add(new Tooltip(hoveredEmojiName));
+        }
+    }
+
+    private void updateHoveredEmoji(Point mousePoint)
+    {
+        this.mousePosition = mousePoint;
+
+        String foundEmoji = null;
+
+        Widget chatbox = client.getWidget(InterfaceID.Chatbox.SCROLLAREA);
+        if (chatbox == null)
+        {
+            hoveredEmojiName = null;
+            return;
+        }
+
+        Widget[] dynamicChildren = chatbox.getDynamicChildren();
+        foundEmoji = checkWidgetsForEmoji(dynamicChildren, mousePoint);
+        
+        hoveredEmojiName = foundEmoji;
+    }
+
+    private String checkWidgetsForEmoji(Widget[] widgets, Point mousePoint)
+    {
+        if (widgets == null)
+        {
+            return null;
+        }
+
+        for (Widget widget : widgets)
+        {
+            if (widget == null)
+            {
+                continue;
+            }
+
+            // Check if mouse is within widget bounds
+            if (isPointInWidget(widget, mousePoint))
+            {
+                String text = widget.getText();
+                if (text != null && text.contains("<img="))
+                {
+                    String hoveredEmoji = findEmojiAtPosition(widget, text, mousePoint);
+                    if (hoveredEmoji != null)
+                    {
+                        return hoveredEmoji;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean isPointInWidget(Widget widget, Point point)
+    {
+        int x = widget.getCanvasLocation().getX();
+        int y = widget.getCanvasLocation().getY();
+        int width = widget.getWidth();
+        int height = widget.getHeight();
+        
+        return point.x >= x && point.x <= x + width && 
+               point.y >= y && point.y <= y + height;
+    }
+
+    private String findEmojiAtPosition(Widget widget, String text, Point mousePoint)
+    {
+        // Create a pattern to find all <img=ID> tags
+        Pattern pattern = Pattern.compile("<img=(\\d+)>");
+        Matcher matcher = pattern.matcher(text);
+        
+        // Get widget position and font metrics
+        net.runelite.api.Point widgetPos = widget.getCanvasLocation();
+        FontMetrics fm = client.getCanvas().getFontMetrics(client.getCanvas().getFont());
+        
+        // Calculate relative mouse position within the widget
+        int relativeX = mousePoint.x - widgetPos.getX();
+        
+        // Parse text and find emote positions
+        int textIndex = 0;
+        int currentX = 0;
+        
+        while (matcher.find())
+        {
+            // Calculate text before this emote
+            String textBefore = text.substring(textIndex, matcher.start());
+            // Remove any HTML tags from text before for width calculation
+            String cleanTextBefore = removeHtmlTags(textBefore);
+            
+            // Calculate X position of this emote
+            int textBeforeWidth = fm.stringWidth(cleanTextBefore);
+            int emoteStartX = currentX + textBeforeWidth;
+            
+            // Look up the emoji to get its actual dimensions
+            String imageIdStr = matcher.group(1);
+            int imageId = Integer.parseInt(imageIdStr);
+            String emojiName = findEmojiNameById(imageId);
+            
+            // Use actual emoji dimensions if available, otherwise use defaults
+            int emoteWidth = 18; // Default width estimate
+            if (emojiName != null)
+            {
+                Emoji emoji = plugin.emojis.get(emojiName);
+                if (emoji != null && emoji.getDimension() != null)
+                {
+                    emoteWidth = emoji.getDimension().width;
+                }
+            }
+            
+            int emoteEndX = emoteStartX + emoteWidth;
+            
+            // Check if mouse is within X bounds of this emote
+            if (relativeX >= emoteStartX && relativeX <= emoteEndX)
+            {
+                return emojiName;
+            }
+            
+            // Update position for next iteration
+            currentX = emoteEndX;
+            textIndex = matcher.end();
+        }
+        
+        return null;
+    }
+
+    private String removeHtmlTags(String text)
+    {
+        if (text == null)
+        {
+            return "";
+        }
+        // Remove HTML tags but preserve the text content
+        return text.replaceAll("<[^>]*>", "");
+    }
+
+    private String findEmojiNameById(int imageId)
+    {
+        for (CustomEmojiPlugin.Emoji emoji : plugin.emojis.values())
+        {
+            if (chatIconManager.chatIconIndex(emoji.getId()) == imageId)
+            {
+                return emoji.getText();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
**Implement image quantization**
This allows us to use any image without the need to quantize it manually. Here's an example demonstrating how well it maintains the accuracy of the image:

https://github.com/user-attachments/assets/50feab6b-a815-44a9-b47a-20e2456a429e

<hr>

**Fix black pixels being treated as transparent pixels**
Apparently, back in the day before alpha channels, (perfect) black pixels were considered a chroma key. This outdated technique causes emotes with black pixels to look a bit funky. I implemented a method to slightly tweak these pixels to a different value that your eyeballs will still parse as black, but now you'll actually see them in the chat.

Before: 
<img width="213" height="40" alt="image" src="https://github.com/user-attachments/assets/b8aa0b6d-95e3-46c5-9a55-389ac3ffcd12" />

After:
<img width="201" height="32" alt="image" src="https://github.com/user-attachments/assets/62e6a394-6360-4a2a-a1bc-735ca3be2d71" />

<hr>

**Implement improved image resizing**
I was using an objectively bad algorithm to resize images. I realized that runelite already has an inbuilt `ImageUtil` class that has a much better resize method, so I switched our resize logic to that.

Before:
<img width="201" height="32" alt="image" src="https://github.com/user-attachments/assets/15745efb-e30a-40be-8b22-2d5e1cc69afd" />

After:
<img width="192" height="30" alt="image" src="https://github.com/user-attachments/assets/bae64ab2-49f9-4f39-9ec5-aee9eff56c63" />

<hr>

**Implement automatic reload on resize setting change**
Toggling the plugin off/on is no longer required to see a change to a resize configuration option. Was super easy to implement this thanks in big part to @io-dream